### PR TITLE
[WIP] Add CLI command to scaffold new projects

### DIFF
--- a/cmd/cli/cmd/new.go
+++ b/cmd/cli/cmd/new.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+var projectTemplate string
+var scmType string
+
+type ProjectTemplateType int
+
+const (
+	Simple ProjectTemplateType = iota
+	Tracks
+	UnknownProjectTemplateType
+)
+
+func stringToTemplateType(s string) (ProjectTemplateType, error) {
+	if s == "simple" {
+		return Simple, nil
+	} else if s == "tracks" {
+		return Tracks, nil
+	}
+
+	return UnknownProjectTemplateType, errors.New("Invalid template type")
+}
+
+type ScmType int
+
+const (
+	None ScmType = iota
+	Git
+	UnknownScmType
+)
+
+func stringToScmType(s string) (ScmType, error) {
+	if s == "none" {
+		return None, nil
+	} else if s == "git" {
+		return Git, nil
+	}
+
+	return UnknownScmType, errors.New("Invalid SCM type")
+}
+
+const gitIgnore = `
+.DS_Store
+.runiac
+`
+
+func init() {
+	newCmd.Flags().StringVar(&projectTemplate, "template", "simple", "Create scaffolding using a predefined project template (simple, tracks)")
+	newCmd.Flags().StringVar(&scmType, "scm", "git", "Initialize a repository in the project directory (none, git)")
+
+	rootCmd.AddCommand(newCmd)
+}
+
+func createSimpleDirectories(name string, fs afero.Fs) error {
+	err := fs.MkdirAll(fmt.Sprintf("%s/step1_initial", name), 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createTracksDirectories(name string, fs afero.Fs) error {
+	err := fs.MkdirAll(fmt.Sprintf("%s/tracks/initial/step1_initial", name), 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func initializeGit(name string, fs afero.Fs) error {
+	// check if git is available
+	_, err := exec.LookPath("git")
+	if err != nil {
+		return nil
+	}
+
+	// initialize the repository
+	cmd := exec.Command("git", "init")
+	cmd.Dir = name
+	_, err = cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	// create a default .gitignore
+	err = afero.WriteFile(fs, fmt.Sprintf("%s/.gitignore", name), []byte(gitIgnore), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var newCmd = &cobra.Command{
+	Use:   "new <project-name>",
+	Short: "Create a new Runiac project",
+	Long:  `Creates scaffolding for a new Runiac project`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// validate template type
+		template, err := stringToTemplateType(projectTemplate)
+		if err != nil {
+			logrus.Error(fmt.Sprintf("Unknown project template '%s' (valid types: simple, tracks)", projectTemplate))
+			return
+		}
+
+		// validate scm type
+		scm, err := stringToScmType(scmType)
+		if err != nil {
+			logrus.Error(fmt.Sprintf("Unknown SCM type '%s' (valid types: none, git)", scmType))
+			return
+		}
+
+		name := args[0]
+		fs := afero.NewOsFs()
+
+		// check if directory already exists
+		exists, _ := afero.DirExists(fs, name)
+		if exists {
+			logrus.Error(fmt.Sprintf("A directory '%s' already exists. Choose a different project name.", name))
+			return
+		}
+
+		// create the project directory
+		err = fs.Mkdir(name, 0755)
+		if err != nil {
+			logrus.WithError(err).Error(err)
+			return
+		}
+
+		// create directory structures
+		switch template {
+		case Simple:
+			err = createSimpleDirectories(name, fs)
+			if err != nil {
+				logrus.WithError(err).Error(err)
+				return
+			}
+
+			break
+
+		case Tracks:
+			err = createTracksDirectories(name, fs)
+			if err != nil {
+				logrus.WithError(err).Error(err)
+				return
+			}
+
+			break
+		}
+
+		// initialize scm repositories
+		switch scm {
+		case Git:
+			err = initializeGit(name, fs)
+			if err != nil {
+				logrus.WithError(err).Error(err)
+			}
+
+			break
+		}
+
+		fmt.Printf("Initialized a new project. You can now run the 'runiac init' command in the %s directory.\n", name)
+	},
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a `new` command to the CLI. The intent is to quickly scaffold a new runiac project with recommended directory structures. By default, this command will attempt to detect if `git` is installed, and if so, will initialize a new repository in the project directory with a default `.gitignore`. This can be disabled by passing `--scm none`.

We can additionally run the `runiac init` command on behalf of the user, but I'm debating this and instead left it as a separate action.

Defaults with no flags (uses `simple` template: just a default track):
```
$ runiac new my-project
Initialized a new project. You can now run the 'runiac init' command in the my-project directory.
$ tree -a my-project/
my-project/
├── .git
├── .gitignore
└── step1_initial
```

Using the `tracks` template (initializes a tracks hierarchy directory instead):
```
$ runiac new my-project --template tracks
Initialized a new project. You can now run the 'runiac init' command in the my-project directory.
$ tree -a my-project/
my-project/
├── .git
├── .gitignore
└── tracks
    └── initial
        └── step1_initial
```


## Issues for these changes

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [X] I have filled out this PR template
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers

N/A

## Relevant Links

N/A

## Further comments

N/A