### PR TITLE
Adds `--local` support for Windows

### DIFF
--- a/cmd/cli/cmd/deploy_test.go
+++ b/cmd/cli/cmd/deploy_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "testing"
+
+func TestSanitizeMachinename(t *testing.T) {
+	tests := map[string]string{
+		"foobar":            "foobar",
+		"foo()bar":          "foo__bar",
+		"!234 Test":         "_234_Test",
+		"!@#$%^&*()":        "__________",
+		"trailing space ":   "trailing_space",
+		"\nwhite space\n\t": "white_space",
+		"domain\\user":      "domain_user",
+	}
+
+	for in, expected := range tests {
+		result := sanitizeMachineName(in)
+		if result != expected {
+			t.Errorf("sanitizeMachineName(\"%s\") = \"%s\"; want \"%s\"", in, result, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes

The `--local` flag was not handled on Windows. This should handle it in a more cross platform way by first checking common environment variables describing the logged in user before shelling out to `whoami`.

For provider compatibility reasons, I included a function to sanitize the "machine name" that replaces non alphanumeric chars with an underscore. See test for details.

## Issues for these changes

<!--
Provide links to Rally for these User Stories/Defects
-->

## Types of changes

<!--
What types of changes does your code introduce to the module?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have filled out this PR template
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers

<!--

Is there anything preventing this PR from being merged?

eg. other PRs that are required, external blockers, etc.

-->

## Relevant Links

<!--
Include any links that may be useful for reviewers. This could include

- Related Pull Requests that are waiting for review,
- Relevant 3rd party documentation
- etc.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->