### PR TITLE
feat: Persist AWS CLI configuration in .runiac directory

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -162,6 +162,9 @@ var deployCmd = &cobra.Command{
 		// persist gcloud cli
 		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/.config/gcloud:/root/.config/gcloud", dir))
 
+		// persist aws cli
+		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/.aws:/root/.aws", dir))
+
 		// persist local terraform state between container executions
 		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/tfstate:/runiac/tfstate", dir))
 


### PR DESCRIPTION
## Proposed changes

In preparation to support a new AWS starter project.

Persist and copy the AWS CLI config directory in `.runiac`. This provides the same login-once experience that the Azure and GCP `entrypoint.sh` scripts offer.

## Issues for these changes

N/A

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [X] I have filled out this PR template
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [] I have added automated tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers

N/A

## Relevant Links

* [AWS CLI config documentation](https://docs.aws.amazon.com/sdkref/latest/guide/file-location.html)

## Further comments

N/A