### PR TITLE
Adding support for passing host system AWS_ prefixed variables into runiac container

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -159,16 +159,16 @@ var deployCmd = &cobra.Command{
 			if strings.HasPrefix(env, "TF_VAR_") {
 				cmd2.Args = append(cmd2.Args, "-e", env)
 			}
-		}
 
-		for _, env := range cmd2.Env {
 			if strings.HasPrefix(env, "ARM_") {
 				cmd2.Args = append(cmd2.Args, "-e", env)
 			}
-		}
 
-		for _, env := range cmd2.Env {
 			if strings.HasPrefix(env, "RUNIAC_") {
+				cmd2.Args = append(cmd2.Args, "-e", env)
+			}
+
+			if strings.HasPrefix(env, "AWS_") {
 				cmd2.Args = append(cmd2.Args, "-e", env)
 			}
 		}


### PR DESCRIPTION
fix(chore): preventing multiple loops over the same array
feature(AWS_ vars): Adding AWS_ env var support into run container

## Proposed changes

Allowing AWS environment variables to be passed to `runiac` run container, as they were previously restricted to only allow prefixed like: TF_VAR_, ARM_, RUNIAC_.

Common environment variables, as presented in the `entrypoint.sh` in the [AWS hello world starter](https://github.com/runiac/runiac-starter-terraform-aws-hello-world/blob/main/entrypoint.sh), demonstrate the need to allow well-known vars to make their way into the container for use.

## Issues for these changes

[<!--
Provide links to Github Issues
-->](https://github.com/Optum/runiac/issues/50)

## Types of changes

<!--
What types of changes does your code introduce to the module?
Put an `x` in the boxes that apply
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (changes to code, which do not change application behavior)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have filled out this PR template
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers

I will be making another PR to the AWS hello world repo adding support for the often used AWS_PROFILE env var.

## Relevant Links

[AWS CLI/SDK Support Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list)

## Further comments

None
