### PR TITLE
persist Azure Az Powershell module between container executions.

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -197,6 +197,9 @@ var deployCmd = &cobra.Command{
 		// persist azure cli between container executions
 		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/.azure:/root/.azure", dir))
 
+		// persist Azure Az Powershell module between container executions. .azure and .Azure are treated as two separate folders on linux, and they can't both be bound to same location on host
+		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/.azurepowershell:/root/.Azure", dir))
+
 		// persist gcloud cli
 		cmd2.Args = append(cmd2.Args, "-v", fmt.Sprintf("%s/.runiac/.config/gcloud:/root/.config/gcloud", dir))
 


### PR DESCRIPTION
## Proposed changes

Persist cache for Azure Az powershell module in between runs

## Issues for these changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Checklist

- [ x  ] I have filled out this PR template
- [ x  ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ x  ] I have added necessary documentation (`README.md`, `CHANGELOG.md`, etc. - if appropriate)

## Dependencies and Blockers

## Further comments

Copied from https://github.com/Optum/runiac/pull/57. i had to reauthor commits under a different email in order to accept CLA

